### PR TITLE
Fix code scanning alert no. 1: Application backup allowed

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
 
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:enableOnBackInvokedCallback="true"
         android:fullBackupContent="@xml/backup_rules"


### PR DESCRIPTION
Fixes [https://github.com/CMPUT301W24T30/ScanPal/security/code-scanning/1](https://github.com/CMPUT301W24T30/ScanPal/security/code-scanning/1)

To fix the problem, we need to set the `android:allowBackup` attribute to `false` in the `application` element of the Android manifest file. This change will prevent the application from being automatically backed up, thereby reducing the risk of sensitive data being exposed.

- Open the `app/src/main/AndroidManifest.xml` file.
- Locate the `application` element.
- Change the value of the `android:allowBackup` attribute from `true` to `false`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
